### PR TITLE
Fix renamed device handler.

### DIFF
--- a/smartapps/augoisms/rainforest-manager.src/rainforest-manager.groovy
+++ b/smartapps/augoisms/rainforest-manager.src/rainforest-manager.groovy
@@ -81,7 +81,7 @@ def createChild() {
 	} else {
         try {
         	log.debug "attempting to create child device"
-        	def newChild = addChildDevice("augoisms", "RainforestEagle", dni, theHub.id, [name:"RainforestEagle", label: "Power Meter"])
+        	def newChild = addChildDevice("augoisms", "Rainforest Handler", dni, theHub.id, [name:"RainforestEagle", label: "Power Meter"])
             log.trace "created ${newChild.displayName} with id $dni"
             schedule(newChild)
         }


### PR DESCRIPTION
Sorry, I missed this in #2.
The device handler changed, so when creating a new device the updated app name ("Rainforest Handler") needs to be used.